### PR TITLE
[WIP] Fix cookie handling

### DIFF
--- a/nicotools/utils.py
+++ b/nicotools/utils.py
@@ -303,11 +303,13 @@ class LogIn:
         session = requests.session()
         cook = self.load_cookies()
 
+        expired = True
+
         if cook:
-            expired = next(cookie for cookie in cook
-                           if cookie.name == 'user_session').is_expired()
-        else:
-            expired = True
+            for cookie in cook:
+                if cookie.name == "user_session":
+                    expired = cookie.is_expired()
+                    break
 
         if auth is not None or cook:
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
         'bs4',
         'aiohttp',
         'tqdm',
-        'multidict'
+        'multidict',
+        'appdirs'
     ],
     entry_points={
         'console_scripts': ['nicotools = nicotools.__init__:main']


### PR DESCRIPTION
日本語がわかりますが、PRの説明は難しいので、英語で説明します。

The current version of nicotools saves the login data cookies in the home directory of
the user, but ignores completely the expiration values. Worse, if the
file is present, it is continually reused even if invalid, preventing a
proper login (sympthom: nicotools keeps on asking for username and
password).

This PR does two major changes:

1. Uses the built-in `httplib.cookiejar` module to actually use a LWP
style (human-readable) cookiejar and check for cookie expiration: if
expired, log in and get new cookies
2. Cookies are saved to user data directories instead of HOME. To this
aim, a third-party module (`appdirs`) is used to make sure it works
cross-platform (win, Mac, Linux: I tested only on Linux).

Some functions have changed quite a bit to assume the file will get
created at all time (likely with this change) but at least the return
value of `save_cookies` is kept the same to make sure other code around
does not break.

This PR is marked as WIP because I did not run the tests yet, and I only
tested it with the functionality of nicotools which I need (comment
retrieval). Please review carefully.